### PR TITLE
before setting locale, make string lowercase.

### DIFF
--- a/src/Http/Middleware/LanguageSwitch.php
+++ b/src/Http/Middleware/LanguageSwitch.php
@@ -21,7 +21,7 @@ class LanguageSwitch
     {
         $lang = Cache::get(auth()->guard(config('nova.guard'))->id().'.locale');
         if ($lang) {
-            app()->setLocale($lang);
+            app()->setLocale(strtolower($lang));
             if (in_array($lang,config('nova-language-switch.rtl-languages'), true)) {
                 Nova::enableRTL();
             }


### PR DESCRIPTION
this is to prevent issues with people capitalizing the key in the config file 'nova-language-switch.php'