### PR TITLE
Delay app locale resolution

### DIFF
--- a/src/LanguageSwitch.php
+++ b/src/LanguageSwitch.php
@@ -13,10 +13,12 @@ class LanguageSwitch extends Tool
     {
         Nova::script('language-switch', __DIR__.'/../dist/js/tool.js');
         Nova::provideToScript([
-            'nova_language_switcher' => [
-                'languages' => config('nova-language-switch.supported-languages'),
-                'current_lang' => app()->getLocale(),
-            ],
+            'nova_language_switcher' => function() {
+                return [
+                    'languages' => config('nova-language-switch.supported-languages'),
+                    'current_lang' => app()->getLocale(),
+                ];
+            }
         ]);
     }
 


### PR DESCRIPTION
Based on the setup, the language change cannot be detected. This delays the config resolution until the request has been made